### PR TITLE
Add grep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - oraclejdk8
 cache:
   directories:
   - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>mockito-kotlin</artifactId>
             <version>1.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+            <version>1.48</version>
+        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>

--- a/src/main/kotlin/net/yeputons/spbau/fall2016/ReplShell.kt
+++ b/src/main/kotlin/net/yeputons/spbau/fall2016/ReplShell.kt
@@ -17,6 +17,7 @@ class ReplShell {
         commandWithArgumentsParser.addCommand("echo", { command, args, env -> EchoCommand(args) })
         commandWithArgumentsParser.addCommand("cat", { command, args, env -> CatCommand(args, env) })
         commandWithArgumentsParser.addCommand("wc", { command, args, env -> WcCommand(args, env) })
+        commandWithArgumentsParser.addCommand("grep", { command, args, env -> GrepCommand(args, env) })
 
         var exitShell: Boolean = false
         commandWithArgumentsParser.addCommand("exit", { command, args, env -> object : BuiltinExecutable() {

--- a/src/main/kotlin/net/yeputons/spbau/fall2016/executables/GrepCommand.kt
+++ b/src/main/kotlin/net/yeputons/spbau/fall2016/executables/GrepCommand.kt
@@ -1,0 +1,156 @@
+package net.yeputons.spbau.fall2016.executables
+
+import com.beust.jcommander.JCommander
+import com.beust.jcommander.Parameter
+import com.beust.jcommander.ParameterException
+import net.yeputons.spbau.fall2016.Environment
+import java.io.BufferedReader
+import java.io.FileInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
+
+/**
+ * Class which contains grep's configuration.
+ */
+class GrepConfig {
+    @Parameter(names = arrayOf("-i"), description = "Ignore case")
+    @JvmField
+    var caseInsensitive: Boolean = false
+
+    @Parameter(names = arrayOf("-w"), description = "Match full words only")
+    @JvmField
+    var fullWordsOnly: Boolean = false
+
+    @Parameter(names = arrayOf("-A"), description = "Print specified number of lines after match")
+    @JvmField
+    var printAfter: Int? = null
+
+    @Parameter(required = true)
+    @JvmField
+    var positionals: List<String> = mutableListOf()
+
+    var regex: Regex = Regex("")
+
+    var files: List<String> = listOf()
+
+    companion object {
+        fun fromArguments(args: List<String>): GrepConfig {
+            val config = GrepConfig()
+            JCommander(config, *args.toTypedArray())
+            if (config.positionals.isEmpty())
+                throw ParameterException("Not enough arguments for grep")
+            try {
+                val regexOptions =
+                        if (config.caseInsensitive) setOf(RegexOption.IGNORE_CASE) else setOf()
+                config.regex = Regex(config.positionals[0], regexOptions)
+            } catch (e: PatternSyntaxException) {
+                throw ParameterException("Invalid pattern for grep: ${e.message}", e)
+            }
+            config.files =
+                    if (config.positionals.size > 1)
+                        config.positionals.subList(1, config.positionals.size)
+                    else
+                        listOf("-")
+            return config
+        }
+    }
+    fun calculateRegex() {
+    }
+
+    override fun toString(): String {
+        return "GrepConfig(caseInsensitive=$caseInsensitive, fullWordsOnly=$fullWordsOnly, printAfter=$printAfter, positionals=$positionals)"
+    }
+}
+
+/**
+ * Helper class which processes lines from different files one by one and produces
+ * expected grep's output, including separators and file names.
+ */
+class GrepProcessor(val config: GrepConfig) {
+    companion object {
+        val WORD_SPLIT_REGEX = Pattern.compile("\\b")
+    }
+
+    private var remainingInGroup = 0
+    var groupsFound = false
+        get() = field
+        private set(newValue) {
+            field = newValue
+        }
+    private var previousPrinted = false
+
+    fun process(line: String, fileNameToPrint: String?): Sequence<String> {
+        val currentMatches =
+                if (config.fullWordsOnly) {
+                    line.split(WORD_SPLIT_REGEX).any({ it.matches(config.regex) })
+                } else {
+                    line.contains(config.regex)
+                }
+        if (currentMatches) {
+            remainingInGroup = (config.printAfter ?: 0) + 1
+        }
+        val isInBlock =
+                if (remainingInGroup > 0) {
+                    remainingInGroup--
+                    true
+                } else {
+                    false
+                }
+        if (!isInBlock) {
+            previousPrinted = false
+            return emptySequence()
+        }
+
+        val result = mutableListOf<String>()
+        if (config.printAfter != null) {
+            if (!previousPrinted && groupsFound) {
+                result += "--"
+            }
+        }
+        result +=
+                if (fileNameToPrint == null) line
+                else {
+                    val sep = if (currentMatches) ":" else "-"
+                    "$fileNameToPrint$sep$line"
+                }
+        groupsFound = true
+        previousPrinted = true
+        return result.asSequence()
+    }
+
+    fun fileEnded() {
+        remainingInGroup = 0
+        previousPrinted = false
+    }
+}
+
+/**
+ * Main class for grep command, parses arguments, reads files and uses GrepProcessor to output the answer.
+ */
+class GrepCommand(val args: List<String>, val env: Environment) : BuiltinExecutable() {
+    override fun call(): Int {
+        val config = GrepConfig.fromArguments(args)
+        val processor = GrepProcessor(config)
+        for (fileName in config.files) {
+            val fileNameToPrint = if (config.files.size > 1) fileName else null
+            try {
+                val inp = if (fileName == "-") input else FileInputStream(env.getFile(fileName))
+                Sequence { BufferedReader(inp.reader(), 1).lines().iterator() }
+                        .flatMap { processor.process(it, fileNameToPrint) }
+                        .forEach { outputWrite("$it\n") }
+                processor.fileEnded()
+                if (fileName != "-") {
+                    try {
+                        inp.close()
+                    } catch (_: IOException) {
+                    }
+                }
+            } catch (e: IOException) {
+                outputWrite(e.toString() + "\n")
+            }
+        }
+        return if (processor.groupsFound) 0 else 1
+    }
+}

--- a/src/main/kotlin/net/yeputons/spbau/fall2016/executables/GrepCommand.kt
+++ b/src/main/kotlin/net/yeputons/spbau/fall2016/executables/GrepCommand.kt
@@ -73,6 +73,17 @@ class GrepProcessor(val config: GrepConfig) {
         val WORD_SPLIT_REGEX = Pattern.compile("\\b")
     }
 
+    /**
+     * If "-A" option is specified, all matched lines are grouped together with
+     * following lines. If two groups are intersecting, they are merged together.
+     * Afterwards consecutive groups are separated with "--" in the output.
+     * Groups are explicitly broken between files via fileEnded().
+     *
+     * remainingInGroup is number of lines which has to be printed until the end of current group.
+     * previousPrinted is whether or not the previous line was in some group (we need
+     * to know in order to properly start a new group or continue the previous).
+     */
+
     private var remainingInGroup = 0
     var groupsFound = false
         get() = field

--- a/src/test/kotlin/net/yeputons/spbau/fall2016/executables/GrepCommandTest.kt
+++ b/src/test/kotlin/net/yeputons/spbau/fall2016/executables/GrepCommandTest.kt
@@ -1,0 +1,166 @@
+package net.yeputons.spbau.fall2016.executables
+
+import com.beust.jcommander.ParameterException
+import net.yeputons.spbau.fall2016.Environment
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class GrepConfigTest {
+    @Test(expected = ParameterException::class) fun testNoArgs() {
+        GrepConfig.fromArguments(listOf())
+    }
+
+    @Test(expected = ParameterException::class) fun testNoPositionals() {
+        GrepConfig.fromArguments(listOf("-i", "-A", "10"))
+    }
+
+    @Test fun testPatternOnly() {
+        val config = GrepConfig.fromArguments(listOf("my pattern"))
+        assertEquals("my pattern", config.regex.pattern)
+        assertEquals(listOf("-"), config.files)
+        assertFalse(config.caseInsensitive)
+        assertFalse(config.fullWordsOnly)
+        assertNull(config.printAfter)
+    }
+
+    @Test fun testOptions() {
+        val config = GrepConfig.fromArguments(listOf("my pattern", "-A", "5", "-i", "-w"))
+        assertEquals("my pattern", config.regex.pattern)
+        assertEquals(listOf("-"), config.files)
+        assertTrue(config.caseInsensitive)
+        assertTrue(config.fullWordsOnly)
+        assertEquals(5, config.printAfter)
+    }
+
+    @Test fun testFiles() {
+        val config = GrepConfig.fromArguments(listOf("my pattern", "file1", "file2"))
+        assertEquals("my pattern", config.regex.pattern)
+        assertEquals(listOf("file1", "file2"), config.files)
+        assertFalse(config.caseInsensitive)
+        assertFalse(config.fullWordsOnly)
+        assertNull(config.printAfter)
+    }
+}
+
+class GrepProcessorTest {
+    @Test fun testSimple() {
+        val proc = GrepProcessor(GrepConfig.fromArguments(listOf("f[ab]o")))
+        assertEquals(listOf<String>(), proc.process("botva", null).toList())
+        assertEquals(listOf<String>("bofaoba"), proc.process("bofaoba", null).toList())
+        assertEquals(listOf<String>("bofboba"), proc.process("bofboba", null).toList())
+        assertEquals(listOf<String>(), proc.process("bofcoba", null).toList())
+    }
+
+    @Test fun testWordBorders() {
+        val proc = GrepProcessor(GrepConfig.fromArguments(listOf("-w", "f[ab]o")))
+        assertEquals(listOf<String>(), proc.process("botva", null).toList())
+        assertEquals(listOf<String>(), proc.process("bofaoba", null).toList())
+        assertEquals(listOf<String>(), proc.process("bofboba", null).toList())
+        assertEquals(listOf<String>(), proc.process("bo faoba", null).toList())
+        assertEquals(listOf<String>(), proc.process("bo fboba", null).toList())
+        assertEquals(listOf<String>(), proc.process("bofao ba", null).toList())
+        assertEquals(listOf<String>(), proc.process("bofbo ba", null).toList())
+        assertEquals(listOf<String>("bo fao ba"), proc.process("bo fao ba", null).toList())
+        assertEquals(listOf<String>("bo fbo ba"), proc.process("bo fbo ba", null).toList())
+        assertEquals(listOf<String>("fao"), proc.process("fao", null).toList())
+        assertEquals(listOf<String>("fbo"), proc.process("fbo", null).toList())
+        assertEquals(listOf<String>(), proc.process("fco", null).toList())
+    }
+
+    @Test fun testCaseInsensitive() {
+        val proc = GrepProcessor(GrepConfig.fromArguments(listOf("-i", "f[ab]o")))
+        assertEquals(listOf<String>(), proc.process("bOtva", null).toList())
+        assertEquals(listOf<String>("boFaoba"), proc.process("boFaoba", null).toList())
+        assertEquals(listOf<String>("boFboba"), proc.process("boFboba", null).toList())
+        assertEquals(listOf<String>(), proc.process("boFcoba", null).toList())
+    }
+
+    @Test fun testFileNames() {
+        val proc = GrepProcessor(GrepConfig.fromArguments(listOf("f[ab]o")))
+        assertEquals(listOf<String>(), proc.process("botva", "a.txt").toList())
+        assertEquals(listOf<String>("a.txt:bofaoba"), proc.process("bofaoba", "a.txt").toList())
+        assertEquals(listOf<String>("b.txt:bofboba"), proc.process("bofboba", "b.txt").toList())
+        assertEquals(listOf<String>(), proc.process("bofcoba", "b.txt").toList())
+    }
+
+    @Test fun testAfter() {
+        val proc = GrepProcessor(GrepConfig.fromArguments(listOf("-A", "2", "foo")))
+        val source = listOf("boo", "foo", "bar", "baz", "boo", "foo", "bax", "foo2", "bam", "bia", "bum")
+        val expected = listOf("f:foo", "f-bar", "f-baz", "--", "f:foo", "f-bax", "f:foo2", "f-bam", "f-bia")
+        val result = source.asSequence().flatMap { proc.process(it, "f") }.toList()
+        assertEquals(expected, result)
+    }
+
+    @Test fun testAfterBreaksBetweenFiles() {
+        val proc = GrepProcessor(GrepConfig.fromArguments(listOf("-A", "1", "foo")))
+        assertEquals(listOf<String>(), proc.process("botva", "a.txt").toList())
+        assertEquals(listOf<String>("a.txt:foo"), proc.process("foo", "a.txt").toList())
+        proc.fileEnded()
+        assertEquals(listOf<String>(), proc.process("bar", "a.txt").toList())
+        assertEquals(listOf<String>("--", "a.txt:foo"), proc.process("foo", "a.txt").toList())
+        assertEquals(listOf<String>("a.txt-bar"), proc.process("bar", "a.txt").toList())
+    }
+}
+
+class GrepCommandTest {
+    @Rule @JvmField val tmpFolder = TemporaryFolder()
+
+    @Test fun testNoMatch() {
+        val (exitCode, output) = ExecutableTest.run(GrepCommand(listOf("foo"), Environment()), "bar")
+        assertNotEquals(0, exitCode)
+        assertEquals("", output)
+    }
+
+    @Test fun testMatch() {
+        val (exitCode, output) = ExecutableTest.run(GrepCommand(listOf("foo"), Environment()), "barfoobar")
+        assertEquals(0, exitCode)
+        assertEquals("barfoobar\n", output)
+    }
+
+    @Test fun testNonExistingFile() {
+        val (exitCode, output) = ExecutableTest.run(GrepCommand(listOf("foo", "some-non-existing-file-for-yeputons-shell"), Environment()))
+        assertNotEquals(0, exitCode)
+        assertNotEquals("", output)
+    }
+
+    @Test fun testExistingFile() {
+        tmpFolder.create()
+        tmpFolder.newFile("a.txt").writeText("content of a.txt\nmeow\nwoof")
+        val env = Environment()
+        env.currentDirectory = tmpFolder.root
+
+        val (exitCode, output) = ExecutableTest.run(GrepCommand(listOf("meo", "a.txt"), env))
+
+        assertEquals(0, exitCode)
+        assertEquals("meow\n", output)
+    }
+
+    @Test fun testExistingFileAbsolutePath() {
+        tmpFolder.create()
+        tmpFolder.newFile("a.txt").writeText("content of a.txt\nmeow\nwoof")
+        val env = Environment()
+        env.currentDirectory = tmpFolder.root
+
+        val path = File(tmpFolder.root, "a.txt").absolutePath
+        val (exitCode, output) = ExecutableTest.run(GrepCommand(listOf("meo", path), env))
+
+        assertEquals(0, exitCode)
+        assertEquals("meow\n", output)
+    }
+
+    @Test fun testMultipleFiles() {
+        tmpFolder.create()
+        tmpFolder.newFile("a.txt").writeText("content of a.txt\nmeow\n")
+        tmpFolder.newFile("b.txt").writeText("content of b.txt\nno meow\nwoof\nbotva\n")
+        val env = Environment()
+        env.currentDirectory = tmpFolder.root
+
+        val (exitCode, output) = ExecutableTest.run(GrepCommand(listOf("-A", "1", "meo", "a.txt", "b.txt"), env))
+
+        assertEquals(0, exitCode)
+        assertEquals("a.txt:meow\n--\nb.txt:no meow\nb.txt-woof\n", output)
+    }
+}


### PR DESCRIPTION
Выбирал из трёх библиотек: Apache Commons CLI, argparse4j, JCommander. Первые две довольно похожи, а вот третья от них выгодно отличается тем, что умеет генерировать парсер по аннотированным полям класса. Её и выбрал - у меня и так планировался класс, содержащий настройки `grep`, а так за несколько простых строчек я ещё и парсер получил. В целом, в предыдущих библиотеках это бы тоже было, но там ещё потребовалось бы вытаскивать данные из парсера по имени - а тут они сразу кладутся в нужные поля.